### PR TITLE
Fix /gonext time

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3701,6 +3701,7 @@ void process(ENetPacket *packet, int sender, int chan)
                             {
                                 strcpy(vi->text,c->mapname);
                                 mode = vi->num1 = c->mode;
+                                time = vi->num2 = c->time;
                             }
                             else fatal("unable to get next map in maprot");
                         }


### PR DESCRIPTION
Fixed the time for which a map is loaded when using /gonext.

This commit fixes the bug that the time for which a map is loaded is a random big number in the displayed vote when a player uses /gonext.

The line that was added is existent in the source files of AssaultCube too.